### PR TITLE
Make dns_search optional

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,7 +30,7 @@ dns_nameservers:
   - 8.8.4.4
 
 # Defines your global dns suffix search
-dns_search: "{{ pri_domain_name }}"
+# dns_search: example.org
 
 # Defines if interfaces, bonds, bridges, vlans, ovs_bonds, ovs_bridges and
 # ovs_interfaces should be brought up after defining. This can be overridden
@@ -198,8 +198,6 @@ ovs_interfaces:
   #   #   - opt: vlan_mode
   #   #     val: access
   #   # parameters:
-
-pri_domain_name: example.org
 
 # Install or not lldp
 config_install_lldp: true

--- a/examples/playbook.yml
+++ b/examples/playbook.yml
@@ -77,7 +77,7 @@
         configure: true
         comment: br0 member
         method: manual
-    pri_domain_name: test.vagrant.local
+    dns_search: test.vagrant.local
   roles:
     - role: ansible-openvswitch
     - role: ansible-config-interfaces

--- a/templates/etc/network/interfaces.j2
+++ b/templates/etc/network/interfaces.j2
@@ -266,6 +266,6 @@ iface {{ item['name'] }} inet {{ item['method']|lower }}
 {% if dns_nameservers is defined and dns_nameservers != [] %}
 dns-nameservers {{ dns_nameservers|join (' ') }}
 {% endif %}
-{% if dns_search is defined and dns_search != None %}
+{% if dns_search is defined %}
 dns-search {{ dns_search }}
 {% endif %}


### PR DESCRIPTION
The condition in the template was always true since `dns_search` was always defined and != None. Comment the parameter in the defaults and update the condition to define dns-search in the interfaces file.

Also remove `pri_domain_name` which might be some legacy unused variable.

Closes: #3