### PR TITLE
feat: Add support to install ifupdown on Debian

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,9 @@ config_ovs_interfaces: false
 # Defines if Open vSwitch ports should be configured as defined
 config_ovs_ports: false
 
+# Define the name of the package which installs ifupdown
+# ifupdown_package: "ifupdown"
+
 # Defines all dns servers to configure
 dns_nameservers:
   - 8.8.8.8

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,4 +1,14 @@
 ---
+- name: debian | Installing ifupdown
+  ansible.builtin.apt:
+    name:
+      - "{{ ifupdown_package }}"
+    state: present
+  become: true
+  register: result
+  until: result is successful
+  when: ifupdown_package is defined
+
 - name: debian | Installing Pre-Req Packages
   ansible.builtin.apt:
     name: ["lldpd"]


### PR DESCRIPTION
Create a variable to define the name of the package to install. This would allow to switch to ifupdown2 if required.