### PR TITLE
style: Factorize the variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,30 +3,6 @@
 
 config_interface_template: etc/network/interfaces.j2
 
-# Defines if network bonds should be configured as defined
-config_network_bonds: false
-
-# Defines if network bridges should be configured as defined
-config_network_bridges: false
-
-# Defines if interfaces should be configured as defined
-config_network_interfaces: false
-
-# Defines if vlans should be configured as defined
-config_network_vlans: false
-
-# Defines if Open vSwitch bonds should be configured as defined
-config_ovs_bonds: false
-
-# Defines if Open vSwitch bridges should be configured as defined
-config_ovs_bridges: false
-
-# Defines if Open vSwitch interfaces should be configured as defined
-config_ovs_interfaces: false
-
-# Defines if Open vSwitch ports should be configured as defined
-config_ovs_ports: false
-
 # Define the name of the package which installs ifupdown
 # ifupdown_package: "ifupdown"
 

--- a/examples/playbook.yml
+++ b/examples/playbook.yml
@@ -1,9 +1,6 @@
 ---
 - hosts: test-nodes
   vars:
-    config_network_bonds: true
-    config_network_bridges: true
-    config_network_interfaces: true
     enable_configured_interfaces_after_defining: true
     network_bonds:
       - name: bond0

--- a/molecule/ovs/converge.yml
+++ b/molecule/ovs/converge.yml
@@ -4,7 +4,6 @@
   vars:
     ifupdown_package: ifupdown
 
-    config_network_interfaces: true
     network_interfaces:
       - name: eth0
         configure: true
@@ -14,7 +13,6 @@
         address: 10.11.0.10
         netmask: 255.255.0.0
 
-    config_ovs_bridges: true
     ovs_bridges:
       - name: vmbr0
         configure: true
@@ -26,7 +24,6 @@
           - eth1
           - vlan25
 
-    config_ovs_interfaces: true
     ovs_interfaces:
       - name: vlan25
         configure: true
@@ -41,7 +38,6 @@
         netmask: 255.255.0.0
         gateway: 10.12.0.254
 
-    config_ovs_ports: true
     ovs_ports:
       - name: eth1
         configure: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,7 +25,7 @@
   become: true
   register: result
   until: result is successful
-  when: config_network_bridges
+  when: network_bridges | length > 0
 
 - name: Installing Bonding Packages
   ansible.builtin.apt:
@@ -34,7 +34,7 @@
   become: true
   register: result
   until: result is successful
-  when: config_network_bonds
+  when: network_bonds | length > 0
 
 - name: Installing VLAN Packages
   ansible.builtin.apt:
@@ -43,7 +43,7 @@
   become: true
   register: result
   until: result is successful
-  when: config_network_vlans
+  when: network_vlans | length > 0
 
 - name: Configuring Defined Interfaces
   ansible.builtin.template:
@@ -54,9 +54,7 @@
     mode: 0644
   register: config_interface
   become: true
-  when: >
-    (config_network_interfaces is defined and
-    config_network_interfaces)
+  when: network_interfaces | length > 0
 
 - name: Restarting Network Interfaces
   ansible.builtin.shell: bash -c "ifdown {{ item.name }} --force && ifup {{ item.name }} --force"
@@ -72,7 +70,7 @@
   become: true
   with_items: "{{ network_vlans }}"
   when: >
-    config_network_vlans and
+    network_vlans | length > 0 and
     (enable_configured_interfaces_after_defining or item['enable']) and
     item['configure'] and
     config_interface['changed']
@@ -82,7 +80,7 @@
   become: true
   with_items: "{{ network_bridges }}"
   when: >
-    config_network_bridges and
+    network_bridges | length > 0 and
     (enable_configured_interfaces_after_defining or item['enable']) and
     item['configure'] and
     config_interface['changed']
@@ -92,7 +90,7 @@
   become: true
   with_items: "{{ ovs_bridges }}"
   when: >
-    config_ovs_bridges and
+    ovs_bridges | length > 0 and
     (enable_configured_interfaces_after_defining or item['enable']) and
     item['configure'] and
     config_interface['changed']
@@ -102,7 +100,7 @@
   become: true
   with_items: "{{ ovs_bonds }}"
   when: >
-    config_ovs_bonds and
+    ovs_bonds | length > 0 and
     (enable_configured_interfaces_after_defining or item['enable']) and
     item['configure'] and
     config_interface['changed']
@@ -112,7 +110,7 @@
   become: true
   with_items: "{{ ovs_interfaces }}"
   when: >
-    config_ovs_interfaces and
+    ovs_interfaces | length > 0 and
     (enable_configured_interfaces_after_defining or item['enable']) and
     item['configure'] and
     config_interface['changed']
@@ -122,7 +120,7 @@
   become: true
   with_items: "{{ ovs_ports }}"
   when: >
-    config_ovs_ports and
+    ovs_ports | length > 0 and
     (enable_configured_interfaces_after_defining or item['enable']) and
     item['configure'] and
     config_interface['changed']

--- a/templates/etc/network/interfaces.j2
+++ b/templates/etc/network/interfaces.j2
@@ -5,7 +5,7 @@
 auto lo
 iface lo inet loopback
 
-{% if config_network_interfaces is defined and config_network_interfaces and network_interfaces != [] %}
+{% if network_interfaces | length > 0 %}
 ########## Network Interfaces
   {% for interface in network_interfaces %}
     {% if interface['configure'] is defined and interface['configure'] %}
@@ -44,7 +44,7 @@ iface {{ interface['name'] }} inet {{ interface['method']|lower }}
 ########## End of Network Interfaces
 {% endif %}
 
-{% if config_network_bonds is defined and config_network_bonds %}
+{% if network_bonds | length > 0 %}
 ########## Network Bonds
   {% for bond in network_bonds %}
     {% if bond['configure'] is defined and bond['configure'] %}
@@ -78,7 +78,7 @@ iface {{ bond['name'] }} inet {{ bond['method']|lower }}
 ########## End of Network Bonds
 {% endif %}
 
-{% if config_network_vlans is defined and config_network_vlans %}
+{% if network_vlans | length > 0 %}
 ########## Network VLANS
   {% for vlan in network_vlans %}
     {% if vlan['configure'] is defined and vlan['configure'] %}
@@ -114,7 +114,7 @@ iface {{ vlan['name'] }} inet {{ vlan['method']|lower }}
 ########## End of Network VLANS
 {% endif %}
 
-{% if config_network_bridges is defined and config_network_bridges %}
+{% if network_bridges | length > 0 %}
 ########## Network Bridges
   {% for bridge in network_bridges %}
     {% if bridge['configure'] is defined and bridge['configure'] %}
@@ -150,7 +150,7 @@ iface {{ bridge['name'] }} inet {{ bridge['method']|lower }}
 ########## End of Network Bridges
 {% endif %}
 
-{% if config_ovs_bonds is defined and config_ovs_bonds %}
+{% if ovs_bonds | length > 0 %}
 ########## OVS Bonds
   {% for ovs_bond in ovs_bonds %}
     {% if ovs_bond['configure'] is defined and ovs_bond['configure'] %}
@@ -188,7 +188,7 @@ iface {{ ovs_bond['name'] }} inet {{ ovs_bond['method']|lower }}
 ########## End of OVS Bonds
 {% endif %}
 
-{% if config_ovs_bridges is defined and config_ovs_bridges %}
+{% if ovs_bridges | length > 0 %}
 ########## OVS Bridges
   {% for ovs_bridge in ovs_bridges %}
     {% if ovs_bridge['configure'] is defined and ovs_bridge['configure'] %}
@@ -226,7 +226,7 @@ iface {{ ovs_bridge['name'] }} inet {{ ovs_bridge['method']|lower }}
 ########## End of OVS Bridges
 {% endif %}
 
-{% if config_ovs_interfaces is defined and config_ovs_interfaces %}
+{% if ovs_interfaces | length > 0 %}
 ########## OVS Interfaces
   {% for ovs_interface in ovs_interfaces %}
     {% if ovs_interface['configure'] is defined and ovs_interface['configure'] %}
@@ -264,7 +264,7 @@ iface {{ ovs_interface['name'] }} inet {{ ovs_interface['method']|lower }}
 ########## End of OVS Interfaces
 {% endif %}
 
-{% if config_ovs_ports is defined and config_ovs_ports %}
+{% if ovs_ports | length > 0 %}
 ########## OVS Ports
 {%   for item in ovs_ports %}
 {%     if item['configure'] is defined and item['configure'] %}


### PR DESCRIPTION
For each network part to configure, there were two variables: a boolean to enable/disable the configuration and the list itself.

Remove the boolean and replace it with a test on the length of the list. All the lists are empty by default. If the list has items, then it must be configured. This will lighten the configuration.

The only downside is that it will no longer be possible to declare items in a list and then disable the configuration of that list, but that does not make sense IMHO.

Closes: #8